### PR TITLE
fix: add test for sometimes failing to load form manager

### DIFF
--- a/__test-utils__/testing-library-react-shim.js
+++ b/__test-utils__/testing-library-react-shim.js
@@ -1,0 +1,44 @@
+/**
+ * Shim that adds renderHook (introduced in @testing-library/react v13)
+ * to the v12 package that ships with this project (React 17 compatible).
+ *
+ * We require the real package by absolute path so Jest's moduleNameMapper
+ * does not create a circular reference back to this file.
+ */
+const React = require('react');
+// Require the real package by resolved path to bypass moduleNameMapper
+const realRTL = require('@testing-library/react/dist/index');
+const { render, act } = realRTL;
+
+function renderHook(renderCallback, options) {
+  const wrapper = options && options.wrapper;
+  const initialProps = options && options.initialProps;
+
+  const results = { current: undefined, error: undefined };
+
+  function TestComponent({ hookProps }) {
+    try {
+      results.current = renderCallback(hookProps);
+    } catch (e) {
+      results.error = e;
+    }
+    return null;
+  }
+
+  function WrappedComponent({ hookProps }) {
+    const inner = React.createElement(TestComponent, { hookProps });
+    return wrapper ? React.createElement(wrapper, null, inner) : inner;
+  }
+
+  const { rerender: baseRerender, unmount } = render(
+    React.createElement(WrappedComponent, { hookProps: initialProps })
+  );
+
+  function rerender(newProps) {
+    baseRerender(React.createElement(WrappedComponent, { hookProps: newProps }));
+  }
+
+  return { result: results, rerender, unmount };
+}
+
+module.exports = { ...realRTL, renderHook };

--- a/__tests__/app/epics/FormManager/index.test.js
+++ b/__tests__/app/epics/FormManager/index.test.js
@@ -353,6 +353,38 @@ describe('Org guard', () => {
   });
 });
 
+// ─── RED: Loading resolves ────────────────────────────────────────────────────
+// Bug 1: When organization is empty the effect guard returns early without ever
+//   calling setLoading(false), so the skeleton shows forever.
+// Bug 2: When retrieveCustomData rejects, the .then() never runs so
+//   setLoading(false) is never called and the skeleton shows forever.
+// Both tests assert that real content (the Puente Forms panel — only rendered
+// when !loading) eventually becomes visible.
+
+describe('Loading resolves', () => {
+  it('shows content (not a skeleton) when organization is empty', async () => {
+    retrieveCustomData.mockResolvedValue([]);
+    render(
+      <FormManager context={mockContext} router={mockRouter} user={{ organization: '' }} />,
+    );
+    await waitFor(
+      () => expect(screen.getByText('Puente Forms')).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+
+  it('shows content (not a skeleton) when retrieveCustomData rejects', async () => {
+    retrieveCustomData.mockRejectedValue(new Error('fetch failed'));
+    render(
+      <FormManager context={mockContext} router={mockRouter} user={{ organization: 'test-org' }} />,
+    );
+    await waitFor(
+      () => expect(screen.getByText('Puente Forms')).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+});
+
 // ─── RED: Phase 1 — + Create form CTA ────────────────────────────────────────
 // If the + Create form button is removed from the catalog, users lose the
 // primary entry point to Form Creator — caught before discoverability regresses.

--- a/__tests__/app/modules/user/index.test.js
+++ b/__tests__/app/modules/user/index.test.js
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom';
+
+// ─── RED: Parse.User object stored directly in BehaviorSubject ───────────────
+// retrieveSignInFunction and retrieveSignUpFunction call userSubject.next(user)
+// where user is a raw Parse.User object. Parse.User stores custom attributes
+// internally and exposes them via .get('organization'), NOT via direct property
+// access. So parseUserValue().organization returns undefined during an active
+// session, only working after a page refresh (when localStorage is read back as
+// a plain JS object). These tests prove the bug exists.
+
+jest.mock('parse', () => ({
+  Parse: {
+    User: {
+      logIn: jest.fn(),
+      logOut: jest.fn(),
+      current: jest.fn(),
+    },
+    Cloud: {
+      run: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('app/modules/user/helpers', () => ({
+  refreshSessionToken: jest.fn().mockResolvedValue(undefined),
+  notificationTypeRestParams: jest.fn(() => null),
+}));
+
+const fakeParseUser = {
+  get: (key) => (key === 'organization' ? 'TestOrg' : undefined),
+  // NOTE: no .organization property — mimics real Parse.User behaviour
+  toJSON: () => ({ objectId: 'u1', username: 'TestCMM', organization: 'TestOrg' }),
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.clearAllMocks();
+  jest.resetModules();
+});
+
+describe('retrieveSignInFunction — user normalization', () => {
+  it('stores a plain object in the subject so .organization is accessible directly', async () => {
+    const { Parse } = require('parse');
+    Parse.User.logIn.mockResolvedValue(fakeParseUser);
+
+    const { retrieveSignInFunction, parseUserValue } = require('app/modules/user');
+    await retrieveSignInFunction('TestCMM', 'password');
+
+    expect(parseUserValue().organization).toBe('TestOrg');
+  });
+});
+
+describe('retrieveSignUpFunction — user normalization', () => {
+  it('stores a plain object in the subject so .organization is accessible directly', async () => {
+    const { Parse } = require('parse');
+    Parse.Cloud.run.mockResolvedValue(fakeParseUser);
+
+    const { retrieveSignUpFunction, parseUserValue } = require('app/modules/user');
+    await retrieveSignUpFunction({ username: 'TestCMM', organization: 'TestOrg' }, null);
+
+    expect(parseUserValue().organization).toBe('TestOrg');
+  });
+});

--- a/__tests__/app/modules/user/useCurrentUser.test.js
+++ b/__tests__/app/modules/user/useCurrentUser.test.js
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom';
+import { renderHook, act } from '@testing-library/react';
+
+// ─── RED: reactive re-render when BehaviorSubject emits ──────────────────────
+// parseUserValue() is a plain snapshot — it cannot trigger a re-render when the
+// subject emits. useCurrentUser() must subscribe to the observable so that any
+// component using it automatically re-renders with the latest user value.
+
+jest.mock('app/modules/user', () => {
+  const { BehaviorSubject } = require('rxjs');
+  const subject = new BehaviorSubject(null);
+  return {
+    __esModule: true,
+    default: {
+      parseUser: () => subject.asObservable(),
+      parseUserValue: () => subject.value,
+    },
+    __subject: subject, // exposed so tests can drive new emissions
+  };
+});
+
+const userModule = require('app/modules/user');
+const subject = userModule.__subject;
+const useCurrentUser = require('app/modules/user/useCurrentUser').default;
+
+describe('useCurrentUser', () => {
+  beforeEach(() => {
+    subject.next(null);
+  });
+
+  it('re-renders with the new user when the subject emits', () => {
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current).toBeNull();
+
+    act(() => {
+      subject.next({ organization: 'NewOrg' });
+    });
+
+    expect(result.current).toEqual({ organization: 'NewOrg' });
+  });
+});

--- a/__tests__/app/modules/user/useCurrentUser.test.js
+++ b/__tests__/app/modules/user/useCurrentUser.test.js
@@ -11,10 +11,8 @@ jest.mock('app/modules/user', () => {
   const subject = new BehaviorSubject(null);
   return {
     __esModule: true,
-    default: {
-      parseUser: () => subject.asObservable(),
-      parseUserValue: () => subject.value,
-    },
+    parseUser: () => subject.asObservable(),
+    parseUserValue: () => subject.value,
     __subject: subject, // exposed so tests can drive new emissions
   };
 });

--- a/__tests__/pages/data/data-analysis/index.test.js
+++ b/__tests__/pages/data/data-analysis/index.test.js
@@ -9,6 +9,11 @@ jest.mock('app/modules/user', () => ({
   parseUserValue: jest.fn(() => null),
 }));
 
+jest.mock('app/modules/user/useCurrentUser', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ organization: 'hook-org' })),
+}));
+
 jest.mock('app/epics/DataAnalyticsManager', () =>
   jest.fn(() => <div data-testid="data-analytics-manager" />));
 
@@ -51,5 +56,16 @@ describe('Content', () => {
   it('renders the DataAnalyticsManager sub-component', () => {
     render(<DataAnalysis />);
     expect(screen.getByTestId('data-analytics-manager')).toBeInTheDocument();
+  });
+});
+
+describe('Reactive user', () => {
+  it('passes the user from useCurrentUser to the DataAnalyticsManager epic', () => {
+    render(<DataAnalysis />);
+    const DataAnalyticsManager = require('app/epics/DataAnalyticsManager');
+    expect(DataAnalyticsManager).toHaveBeenCalledWith(
+      expect.objectContaining({ user: expect.objectContaining({ organization: 'hook-org' }) }),
+      expect.anything(),
+    );
   });
 });

--- a/__tests__/pages/forms/form-creator/index.test.js
+++ b/__tests__/pages/forms/form-creator/index.test.js
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn(() => ({ push: jest.fn() })) }));
+jest.mock('app/store', () => ({
+  useGlobalState: () => ({ contextManagment: { addPropToStore: jest.fn(), store: {} } }),
+}));
+jest.mock('app/modules/user', () => ({
+  parseUserValue: jest.fn(() => ({ organization: 'static-org' })),
+}));
+jest.mock('app/modules/user/useCurrentUser', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ organization: 'hook-org' })),
+}));
+jest.mock('app/epics/FormCreator', () => jest.fn(() => <div data-testid="form-creator-epic" />));
+jest.mock('app/impacto-design-system', () => ({
+  AppShell: ({ children }) => <div>{children}</div>,
+}));
+jest.mock('next-i18next/serverSideTranslations', () => ({
+  serverSideTranslations: jest.fn(() => Promise.resolve({})),
+}));
+
+const FormCreatorPage = require('pages/forms/form-creator/index').default;
+
+describe('Reactive user', () => {
+  it('passes the user from useCurrentUser to the FormCreator epic', () => {
+    render(<FormCreatorPage />);
+    const FormCreator = require('app/epics/FormCreator');
+    expect(FormCreator).toHaveBeenCalledWith(
+      expect.objectContaining({ user: expect.objectContaining({ organization: 'hook-org' }) }),
+      expect.anything(),
+    );
+  });
+});

--- a/__tests__/pages/forms/form-manager/index.test.js
+++ b/__tests__/pages/forms/form-manager/index.test.js
@@ -13,6 +13,11 @@ jest.mock('app/modules/user', () => ({
   parseUserValue: jest.fn(() => ({ organization: 'test-org' })),
 }));
 
+jest.mock('app/modules/user/useCurrentUser', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ organization: 'hook-org' })),
+}));
+
 jest.mock('app/store', () => ({
   useGlobalState: jest.fn(() => ({
     contextManagment: { addPropToStore: jest.fn(), store: {} },
@@ -63,5 +68,16 @@ describe('Content', () => {
   it('renders the FormManager epic sub-component', () => {
     render(<Manager />);
     expect(screen.getByTestId('form-manager-epic')).toBeInTheDocument();
+  });
+});
+
+describe('Reactive user', () => {
+  it('passes the user from useCurrentUser to the FormManager epic', () => {
+    render(<Manager />);
+    const FormManager = require('app/epics/FormManager');
+    expect(FormManager).toHaveBeenCalledWith(
+      expect.objectContaining({ user: expect.objectContaining({ organization: 'hook-org' }) }),
+      expect.anything(),
+    );
   });
 });

--- a/__tests__/pages/forms/form-marketplace/index.test.js
+++ b/__tests__/pages/forms/form-marketplace/index.test.js
@@ -11,6 +11,10 @@ jest.mock('app/store', () => ({
   useGlobalState: () => ({ contextManagment: { addPropToStore: jest.fn(), store: {} } }),
 }));
 jest.mock('app/modules/user', () => ({ parseUserValue: () => ({ organization: 'test-org' }) }));
+jest.mock('app/modules/user/useCurrentUser', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ organization: 'hook-org' })),
+}));
 jest.mock('app/epics/FormMarketplace', () => jest.fn(() => <div data-testid="marketplace-epic" />));
 jest.mock('app/impacto-design-system', () => ({
   AppShell: ({ children }) => <div>{children}</div>,
@@ -40,5 +44,16 @@ describe('Epic rendered', () => {
   it('renders the FormMarketplace epic below the header', () => {
     render(<Marketplace />);
     expect(screen.getByTestId('marketplace-epic')).toBeInTheDocument();
+  });
+});
+
+describe('Reactive user', () => {
+  it('passes the user from useCurrentUser to the FormMarketplace epic', () => {
+    render(<Marketplace />);
+    const FormMarketplace = require('app/epics/FormMarketplace');
+    expect(FormMarketplace).toHaveBeenCalledWith(
+      expect.objectContaining({ user: expect.objectContaining({ organization: 'hook-org' }) }),
+      expect.anything(),
+    );
   });
 });

--- a/app/epics/FormManager/index.js
+++ b/app/epics/FormManager/index.js
@@ -30,7 +30,7 @@ function FormManager({ context, router, user }) {
   const [workflowData, setWorkflowData] = useState({});
   const [noWorkflowData, setNoWorkflowData] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [selectedForm, setSelectedForm] = useState(null);
 
   const organization = user?.organization || '';
@@ -59,29 +59,23 @@ function FormManager({ context, router, user }) {
     refreshWorkflowData();
   }, [organization]);
 
+  const appendToCategory = (map, key, record) => {
+    // eslint-disable-next-line no-param-reassign
+    map[key] = key in map ? map[key].concat([record]) : [record];
+  };
+
   const refreshWorkflowData = async () => {
     setLoading(true);
-    retrieveCustomData(organization).then((records) => {
+    try {
+      const records = await retrieveCustomData(organization);
       const tableDataByCategory = {};
       records.forEach((record) => {
         if (record.active !== 'false') {
           if (!isArray(record.workflows) || record.workflows.length < 1) {
-            if ('No Workflow Assigned' in tableDataByCategory) {
-              tableDataByCategory['No Workflow Assigned'] = tableDataByCategory[
-                'No Workflow Assigned'
-              ].concat([record]);
-            } else {
-              tableDataByCategory['No Workflow Assigned'] = [record];
-            }
+            appendToCategory(tableDataByCategory, 'No Workflow Assigned', record);
           } else if (isArray(record.workflows)) {
             record.workflows.forEach((workflow) => {
-              if (workflow in tableDataByCategory) {
-                tableDataByCategory[workflow] = tableDataByCategory[
-                  workflow
-                ].concat([record]);
-              } else {
-                tableDataByCategory[workflow] = [record];
-              }
+              appendToCategory(tableDataByCategory, workflow, record);
             });
           }
         }
@@ -90,8 +84,11 @@ function FormManager({ context, router, user }) {
       delete tableDataByCategory['No Workflow Assigned'];
       delete tableDataByCategory.Puente;
       setWorkflowData(tableDataByCategory);
+    } catch {
+      // network / parse error — loading flag is cleared in finally; content remains visible
+    } finally {
       setLoading(false);
-    });
+    }
   };
 
   const passDataToFormCreator = (action, data) => {
@@ -149,12 +146,12 @@ function FormManager({ context, router, user }) {
           </div>
           {loading && (
             <div className={styles.section}>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 'var(--spacer-m)' }}>
+              <div className={styles.skeletonList}>
                 {[55, 70, 40, 60].map((w, i) => (
                   // eslint-disable-next-line react/no-array-index-key
-                  <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                  <div key={i} className={styles.skeletonRow}>
                     <Skeleton width={`${w}%`} height={14} />
-                    <Skeleton width={60} height={22} style={{ borderRadius: 6 }} />
+                    <Skeleton width={60} height={22} style={{ borderRadius: 'var(--tk-dlite-semantic-border-radius-sm)' }} />
                   </div>
                 ))}
               </div>

--- a/app/epics/FormManager/index.module.scss
+++ b/app/epics/FormManager/index.module.scss
@@ -160,3 +160,16 @@
   align-items: center;
   gap: var(--spacer-s);
 }
+
+.skeletonList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacer-sm);
+  padding: var(--spacer-m);
+}
+
+.skeletonRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-sm);
+}

--- a/app/modules/user/index.js
+++ b/app/modules/user/index.js
@@ -14,8 +14,9 @@ const retrieveSignUpFunction = async (params, type) => {
     if (restParamsData) signupParams.restParams = restParamsData;
     Parse.Cloud.run('signup', signupParams).then((user) => {
     console.log(`User registered successful ${user}`); // eslint-disable-line
-      userSubject.next(user);
-      localStorage.setItem('user', JSON.stringify(user));
+      const userJSON = user.toJSON();
+      userSubject.next(userJSON);
+      localStorage.setItem('user', JSON.stringify(userJSON));
       resolve(user);
     }, (error) => {
       reject(error);
@@ -30,8 +31,9 @@ const retrieveSignInFunction = async (username, password) => {
   // sign in with either phonenumber (username) or email handled with logIn
     Parse.User.logIn(String(username), String(password)).then((user) => {
     console.log(`User logged in successful with username: ${user.get('username')}`); // eslint-disable-line
-      userSubject.next(user);
-      localStorage.setItem('user', JSON.stringify(user));
+      const userJSON = user.toJSON();
+      userSubject.next(userJSON);
+      localStorage.setItem('user', JSON.stringify(userJSON));
       resolve(user);
     }, (error) => {
       console.log(`Error: ${error.code} ${error.message}`); // eslint-disable-line

--- a/app/modules/user/useCurrentUser.js
+++ b/app/modules/user/useCurrentUser.js
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import userModule from 'app/modules/user';
+import { parseUser, parseUserValue } from 'app/modules/user';
 
 export default function useCurrentUser() {
-  const [user, setUser] = useState(() => userModule.parseUserValue());
+  const [user, setUser] = useState(() => parseUserValue());
 
   useEffect(() => {
-    const sub = userModule.parseUser().subscribe(setUser);
+    const sub = parseUser().subscribe(setUser);
     return () => sub.unsubscribe();
   }, []);
 

--- a/app/modules/user/useCurrentUser.js
+++ b/app/modules/user/useCurrentUser.js
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+import userModule from 'app/modules/user';
+
+export default function useCurrentUser() {
+  const [user, setUser] = useState(() => userModule.parseUserValue());
+
+  useEffect(() => {
+    const sub = userModule.parseUser().subscribe(setUser);
+    return () => sub.unsubscribe();
+  }, []);
+
+  return user;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,8 @@ const createJestConfig = nextJest({ dir: './' });
 module.exports = createJestConfig({
   testEnvironment: 'jest-environment-jsdom',
   moduleDirectories: ['node_modules', '<rootDir>'],
+  moduleNameMapper: {
+    '^@testing-library/react$':
+      '<rootDir>/__test-utils__/testing-library-react-shim.js',
+  },
 });

--- a/pages/data/data-analysis/index.js
+++ b/pages/data/data-analysis/index.js
@@ -1,9 +1,9 @@
 import DataAnalyticsManager from 'app/epics/DataAnalyticsManager';
 import { AppShell, PageHeader } from 'app/impacto-design-system';
-import { parseUserValue } from 'app/modules/user';
+import useCurrentUser from 'app/modules/user/useCurrentUser';
 
 export default function Forms() {
-  const user = parseUserValue();
+  const user = useCurrentUser();
   return (
     <AppShell breadcrumb={['Data', 'Analysis']}>
       <PageHeader title="Data Analysis" />

--- a/pages/forms/form-creator/index.js
+++ b/pages/forms/form-creator/index.js
@@ -1,6 +1,6 @@
 import FormCreator from 'app/epics/FormCreator';
 import { AppShell } from 'app/impacto-design-system';
-import { parseUserValue } from 'app/modules/user';
+import useCurrentUser from 'app/modules/user/useCurrentUser';
 import { useGlobalState } from 'app/store';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
@@ -10,7 +10,7 @@ export async function getStaticProps({ locale }) {
 
 export default function Forms() {
   const { contextManagment } = useGlobalState();
-  const user = parseUserValue();
+  const user = useCurrentUser();
   return (
     <AppShell breadcrumb={['Forms', 'Form Creator']} fullBleed>
       <FormCreator

--- a/pages/forms/form-manager/index.js
+++ b/pages/forms/form-manager/index.js
@@ -1,6 +1,6 @@
 import FormManager from 'app/epics/FormManager';
 import { AppShell, PageHeader } from 'app/impacto-design-system';
-import { parseUserValue } from 'app/modules/user';
+import useCurrentUser from 'app/modules/user/useCurrentUser';
 import { useGlobalState } from 'app/store';
 import { useRouter } from 'next/router';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
@@ -13,7 +13,7 @@ export async function getStaticProps({ locale }) {
 export default function Manager() {
   const { contextManagment } = useGlobalState();
   const router = useRouter();
-  const user = parseUserValue();
+  const user = useCurrentUser();
 
   return (
     <AppShell breadcrumb={['Forms', 'Form Manager']}>

--- a/pages/forms/form-marketplace/index.js
+++ b/pages/forms/form-marketplace/index.js
@@ -1,6 +1,6 @@
 import FormMarketplace from 'app/epics/FormMarketplace';
 import { AppShell, PageHeader } from 'app/impacto-design-system';
-import { parseUserValue } from 'app/modules/user';
+import useCurrentUser from 'app/modules/user/useCurrentUser';
 import { useGlobalState } from 'app/store';
 import { useRouter } from 'next/router';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
@@ -12,7 +12,7 @@ export async function getStaticProps({ locale }) {
 export default function Marketplace() {
   const { contextManagment } = useGlobalState();
   const router = useRouter();
-  const user = parseUserValue();
+  const user = useCurrentUser();
 
   return (
     <AppShell breadcrumb={['Forms', 'Marketplace']}>


### PR DESCRIPTION
## Summary

- **Root cause fix:** After login, `retrieveSignInFunction`/`retrieveSignUpFunction` stored the raw Parse.User object in the BehaviorSubject. Parse.User exposes custom attributes (e.g. `organization`) only via `.get()`, so `user.organization` returned `undefined`, causing the org guard to always skip the data fetch during an active session. After a page refresh the BehaviorSubject reinitialised from localStorage (a plain JS object) so the page worked — explaining the intermittent failure.
- **Fix:** Call `user.toJSON()` before storing in the BehaviorSubject so the value is always a plain JS object consistent with the localStorage-restored shape.
- **Reactive user hook:** Introduced `useCurrentUser` — a React hook that subscribes to the BehaviorSubject so pages re-render when the user changes (login, logout), replacing the non-reactive `parseUserValue()` snapshot call in all four affected pages (`form-manager`, `form-creator`, `form-marketplace`, `data-analysis`).
- **Loading state bug:** `FormManager` initialised `loading` as `true` and had no error handling in `refreshWorkflowData`, so the skeleton spinner showed forever when the org was empty or the fetch failed. Fixed by initialising `loading: false` and adding a `try/catch/finally` block.

## Test plan

- [x] `yarn jest` — 400/400 tests green
- [x] `retrieveSignInFunction` — new test: `parseUserValue().organization` is directly accessible (not via `.get()`) after sign-in resolves
- [x] `retrieveSignUpFunction` — same assertion
- [x] `useCurrentUser` — new hook test: component re-renders with updated user when BehaviorSubject emits
- [x] `FormManager` — new tests: loading resolves when org is empty; loading resolves when fetch rejects
- [x] Org guard tests: `retrieveCustomData` not called with empty org; called with real org after rerender
- [x] All 4 pages: discriminating test proves epic receives user from `useCurrentUser`, not from `parseUserValue` snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)